### PR TITLE
Update DNS docs

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -62,7 +62,9 @@ See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master
 
 ## DNS Record
 
-As this module creates an External HTTPS Load Balancer together with a managed SSL certificate for the domain you provided, an A record has to be created for your domain to successfully provision the certificate.
+This example uses Cloud DNS to add an A record containing the load balancer IP address. If you don't use Cloud DNS, please add the A record using the load balancer IP address on the platform where you've registered your domain.
+
+It's a requirement to add the A record to the domain record set in order to sucessfully provision the certificate!
 
 ### Example
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -60,7 +60,9 @@ See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master
 
 ## DNS Record
 
-As this module creates an External HTTPS Load Balancer together with a managed SSL certificate for the domain you provided, an A record has to be created for your domain to successfully provision the certificate.
+This example uses Cloud DNS to add an A record containing the load balancer IP address. If you don't use Cloud DNS, please add the A record using the load balancer IP address on the platform where you've registered your domain.
+
+It's a requirement to add the A record to the domain record set in order to sucessfully provision the certificate!
 
 ### Example
 


### PR DESCRIPTION
## what
* Updated the DNS documentation to include a reference for non Cloud DNS users.

## why
* There's a high chance that people manage their DNS outside of GCP.
