### PR TITLE
Add `documentation` label to patch release

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'documentation'
   default: 'minor'
 
 categories:


### PR DESCRIPTION
## what
* Add docs label to patch to prevent minor releases
