### PR TITLE
remove the terraform-google-modules/container-vm/google version constraint, hardpin a version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,6 @@ resource "google_compute_instance_template" "atlantis" {
 
 module "atlantis" {
   source  = "terraform-google-modules/container-vm/google"
-  version = "~> 2.0"
 
   container = {
     image = var.image

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,7 @@ resource "google_compute_instance_template" "atlantis" {
 
 module "atlantis" {
   source  = "terraform-google-modules/container-vm/google"
+  version = "3.1.0"
 
   container = {
     image = var.image


### PR DESCRIPTION
Closes #65 

## what
* To avoid breaking changes we should pin a version.
