### PR TITLE
Add a `tags` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance running Atlantis | <pre>object({<br>    email  = string,<br>    scopes = list(string)<br>  })</pre> | <pre>{<br>  "email": "",<br>  "scopes": [<br>    "cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_spot_machine_enabled"></a> [spot\_machine\_enabled](#input\_spot\_machine\_enabled) | A Spot VM is discounted Compute Engine capacity that may be preemptively stopped or deleted by Compute Engine if the capacity is needed | `bool` | `false` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Name of the subnetwork to attach a network interface to | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to attach to the instance running Atlantis. | `list(string)` | `[]` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The zone that instances should be created in | `string` | n/a | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "google_compute_instance_template" "atlantis" {
   description = "This template is used to create VMs that run Atlantis in a containerized environment using Docker"
   region      = var.region
 
-  tags = ["atlantis"]
+  tags = concat(["atlantis"], var.tags)
 
   metadata_startup_script = templatefile("${path.module}/startup-script.sh", { disk_name = "atlantis-disk-0" })
 

--- a/startup-script.sh
+++ b/startup-script.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2154
 
 # Exit immediately if a command returns a non-zero code
 set -e

--- a/variables.tf
+++ b/variables.tf
@@ -81,6 +81,12 @@ variable "block_project_ssh_keys_enabled" {
   default     = false
 }
 
+variable "tags" {
+  type        = list(string)
+  description = "Tags to attach to the instance running Atlantis."
+  default     = []
+}
+
 variable "project" {
   type        = string
   description = "The ID of the project in which the resource belongs."


### PR DESCRIPTION
## what
* Added a variable called `tags`.

## why
* Users should be able to assign tags to the instance running atlantis.
