### PR TITLE
Document that we don't route nor redirect any HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,15 @@ See the [`examples`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/m
 
 ## FAQ
 
+### When sending an HTTP request, I'm receiving an ERR_EMPTY_RESPONSE error.
+
+We expect you to use HTTPS because we are not routing or redirecting any HTTP requests.
+
 ### My VM experienced an outage and is taking some time to restart
 
 It may take up to three minutes for the Managed Instance Group to safely shut down and recreate the VM before it is considered healthy again.
 
-### Even though terraform apply worked correctly, I am receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error.
+### Even though terraform apply worked correctly, I' receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error.
 
 This error indicates that the Google Cloud Managed SSL certificate is not yet fully provisioned. 
 If all configurations are correct, it may take up to 25 minutes for the certificate to be provisioned. 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We expect you to use HTTPS because we are not routing or redirecting any HTTP re
 
 It may take up to three minutes for the Managed Instance Group to safely shut down and recreate the VM before it is considered healthy again.
 
-### Even though terraform apply worked correctly, I' receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error.
+### Even though terraform apply worked correctly, I'm receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error.
 
 This error indicates that the Google Cloud Managed SSL certificate is not yet fully provisioned. 
 If all configurations are correct, it may take up to 25 minutes for the certificate to be provisioned. 


### PR DESCRIPTION
## what
* Added an entry to the documentation that states that we don't route nor redirect any HTTP requests, and expect you to use HTTPS.

* HTTP is ancient.

## why
* Provide the justifications for the changes

## references
* Closes #75 
