### PR TITLE
Introduce startup script var

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_region"></a> [region](#input\_region) | The region that resources should be created in | `string` | n/a | yes |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance running Atlantis | <pre>object({<br>    email  = string,<br>    scopes = list(string)<br>  })</pre> | <pre>{<br>  "email": "",<br>  "scopes": [<br>    "cloud-platform"<br>  ]<br>}</pre> | no |
 | <a name="input_spot_machine_enabled"></a> [spot\_machine\_enabled](#input\_spot\_machine\_enabled) | A Spot VM is discounted Compute Engine capacity that may be preemptively stopped or deleted by Compute Engine if the capacity is needed | `bool` | `false` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | A startup script that will be executed by the instance when it is first started. | `string` | `null` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Name of the subnetwork to attach a network interface to | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to attach to the instance running Atlantis. | `list(string)` | `[]` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The zone that instances should be created in | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,8 @@ resource "google_compute_instance_template" "default" {
 
   tags = concat(["atlantis"], var.tags)
 
+  metadata_startup_script = var.startup_script
+
   metadata = {
     "gce-container-declaration" = module.container.metadata_value
     "user-data"                 = data.cloudinit_config.config.rendered

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "spot_machine_enabled" {
   default     = false
 }
 
+variable "startup_script" {
+  type        = string
+  description = "A startup script that runs during the boot cycle when you first launch an instance"
+  default     = null
+}
+
 variable "disk_kms_key_self_link" {
   type        = string
   description = "The self link of the encryption key that is stored in Google Cloud KMS"
@@ -92,12 +98,12 @@ variable "iap" {
 
 variable "tags" {
   type        = list(string)
-  description = "Tags to attach to the instance running Atlantis."
+  description = "Tags to attach to the instance running Atlantis"
   default     = []
 }
 
 variable "project" {
   type        = string
-  description = "The ID of the project in which the resource belongs."
+  description = "The ID of the project in which the resource belongs"
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "disk_kms_key_self_link" {
 
 variable "image" {
   type        = string
-  description = "Docker image. This is most often a reference to a container located in a container registry."
+  description = "Docker image. This is most often a reference to a container located in a container registry"
   default     = "ghcr.io/runatlantis/atlantis:latest"
 }
 


### PR DESCRIPTION
As proposed in #41, we should allow users to bring their own start-up script.

## what
* Created a `startup_script` variable.

## why
* Next to cloudinit, users should be able to execute their own startup script.

## references
* Closes #41 

