### PR TITLE
Fix module idempotency by setting sample_rate on backend service log_config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -184,7 +184,7 @@ resource "google_compute_instance_template" "default" {
 
   project = var.project
 
-  # Instance Templates cannot be updated after creation with the Google Cloud Platform API. 
+  # Instance Templates cannot be updated after creation with the Google Cloud Platform API.
   # In order to update an Instance Template, Terraform will destroy the existing resource and create a replacement
   lifecycle {
     create_before_destroy = true
@@ -279,7 +279,8 @@ resource "google_compute_backend_service" "default" {
   health_checks                   = [google_compute_health_check.default.id]
 
   log_config {
-    enable = true
+    enable      = true
+    sample_rate = 1
   }
 
   backend {


### PR DESCRIPTION
## what
Set `sample_rate` to `1` (default value) on `google_compute_backend_service` resource `log_config` block

## why
When used as-is, the module is not idempotent, and results in change on each apply:
```
Terraform will perform the following actions:

  # module.atlantis.google_compute_backend_service.default will be updated in-place
  ~ resource "google_compute_backend_service" "default" {
        id                              = "projects/argyle-security-admin/global/backendServices/atlantis"
        name                            = "atlantis"
        # (16 unchanged attributes hidden)

      ~ log_config {
          - sample_rate = 1 -> null
            # (1 unchanged attribute hidden)
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

## references
[google_compute_backend_service sample_rate documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service#sample_rate)

The ideal solution would be to provide an input variable for setting both logging and its sample rate. Maybe it can be handled in a separate feature. Meanwhile this is a quick workaround which doesn't change the current behavior and makes the module idempotent.
