### PR TITLE
Enable secure boot & add an option to enable OS login

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you prefer an example that includes the above resources, see [`complete examp
 Here are some examples to choose from. Look at the prerequisites above to find one that is appropriate for your configuration.
 
 - [Basic](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic)
-- [Complete](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete) 
+- [Complete](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete)
 - [Secure Environment Variables](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/secure-env-vars)
 
 ## How to deploy
@@ -149,7 +149,7 @@ resource "google_iap_web_iam_member" "member" {
 
 ## FAQ
 
-### When sending an HTTP request, I'm receiving an ERR_EMPTY_RESPONSE error.
+### When sending an HTTP request, I'm receiving an ERR_EMPTY_RESPONSE error
 
 We expect you to use HTTPS because we are not routing or redirecting any HTTP requests.
 
@@ -157,7 +157,7 @@ We expect you to use HTTPS because we are not routing or redirecting any HTTP re
 
 It may take up to three minutes for the Managed Instance Group to safely shut down and recreate the VM before it is considered healthy again.
 
-### Even though terraform apply worked correctly, I'm receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error.
+### Even though terraform apply worked correctly, I'm receiving an ERR_SSL_VERSION_OR_CIPHER_MISMATCH error
 
 This error indicates that the Google Cloud Managed SSL certificate is not yet fully provisioned.
 If all configurations are correct, it may take up to 25 minutes for the certificate to be provisioned.
@@ -213,6 +213,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | [random_string.random](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [cloudinit_config.config](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
 | [google_compute_image.cos](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_netblock_ip_ranges.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/netblock_ip_ranges) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -178,6 +178,7 @@ resource "google_compute_instance_template" "default" {
   shielded_instance_config {
     enable_integrity_monitoring = true
     enable_vtpm                 = true
+    enable_secure_boot          = true
   }
 
   service_account {

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ resource "google_compute_instance_template" "default" {
     user-data                 = data.cloudinit_config.config.rendered
     google-logging-enabled    = true
     block-project-ssh-keys    = var.block_project_ssh_keys_enabled
+    enable-oslogin            = var.enable_oslogin
   }
 
   # Using the below scheduling configuration,

--- a/main.tf
+++ b/main.tf
@@ -121,10 +121,10 @@ resource "google_compute_instance_template" "default" {
   metadata_startup_script = var.startup_script
 
   metadata = {
-    "gce-container-declaration" = module.container.metadata_value
-    "user-data"                 = data.cloudinit_config.config.rendered
-    "google-logging-enabled"    = true
-    "block-project-ssh-keys"    = var.block_project_ssh_keys_enabled
+    gce-container-declaration = module.container.metadata_value
+    user-data                 = data.cloudinit_config.config.rendered
+    google-logging-enabled    = true
+    block-project-ssh-keys    = var.block_project_ssh_keys_enabled
   }
 
   # Using the below scheduling configuration,

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "block_project_ssh_keys_enabled" {
   default     = false
 }
 
+variable "enable_oslogin" {
+  type        = bool
+  description = "Enables OS Login service on the VM"
+  default     = false
+}
+
 variable "iap" {
   type = object({
     oauth2_client_id     = string


### PR DESCRIPTION
## what
* Unquoted metadata keys
* Enabled secure boot (hard-coded)
* Added an option to enable OS Login (off by default)
* Documented `google_netblock_ip_ranges` data source

## why
* Removing quotes from metadata keys is probably a matter of preference, but all the terraform examples in the provider documentation (e.g. [google_compute_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) & [google_compute_instance_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template)) do not quote keys
* [Secure boot](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot) is an additional security feature to harden the resulting VM -- since VTPM & integrity monitoring were already turned on by default, it only makes sense to have it on too
* OS Login allows to manage access to the VM using IAM permissions rather than injecting SSH keys each time. It was left off by default, but due to adding a new metadata key, this becomes a breaking change as it will force re-creation of the instance
* Lastly, documented an additional data source added in https://github.com/bschaatsbergen/terraform-gce-atlantis/pull/88 -- not sure what the policy for adding unrelated changes to the PR are, if needed, I can create a separate PR for that