### PR TITLE
Add an ability to enable OS Login

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -121,10 +121,11 @@ resource "google_compute_instance_template" "default" {
   metadata_startup_script = var.startup_script
 
   metadata = {
-    "gce-container-declaration" = module.container.metadata_value
-    "user-data"                 = data.cloudinit_config.config.rendered
-    "google-logging-enabled"    = true
-    "block-project-ssh-keys"    = var.block_project_ssh_keys_enabled
+    gce-container-declaration = module.container.metadata_value
+    user-data                 = data.cloudinit_config.config.rendered
+    google-logging-enabled    = true
+    block-project-ssh-keys    = var.block_project_ssh_keys_enabled
+    enable-oslogin            = var.enable_oslogin
   }
 
   # Using the below scheduling configuration,

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,12 @@ variable "block_project_ssh_keys_enabled" {
   default     = false
 }
 
+variable "enable_oslogin" {
+  type        = bool
+  description = "Enables OS Login service on the VM"
+  default     = false
+}
+
 variable "iap" {
   type = object({
     oauth2_client_id     = string


### PR DESCRIPTION
## what
* Added an option to enable OS Login (off by default)

## why
* OS Login allows to manage access to the VM using IAM permissions rather than injecting SSH keys each time. It was left off by default, but due to adding a new metadata key, this becomes a **breaking change as it will force re-creation of the instance**

## references
* [OS Login documentation](https://cloud.google.com/compute/docs/oslogin/)
