### PR TITLE
Enable secure boot

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,6 +177,7 @@ resource "google_compute_instance_template" "default" {
   shielded_instance_config {
     enable_integrity_monitoring = true
     enable_vtpm                 = true
+    enable_secure_boot          = true
   }
 
   service_account {


### PR DESCRIPTION
## what
* Set `enable_secure_boot` to `true` (hardcoded)

## why
* [Secure boot](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot) is an additional security feature to harden the resulting VM -- since VTPM & integrity monitoring were already turned on by default, it only makes sense to have it on too
* Setting this value will force the instance to be recreated, so **this is a breaking change**
