### PR TITLE
Add redirect to domain for unmatched requests

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -331,9 +331,22 @@ resource "google_compute_backend_service" "iap" {
 }
 
 resource "google_compute_url_map" "default" {
-  name            = var.name
-  project         = var.project
-  default_service = google_compute_backend_service.default.id
+  name    = var.name
+  project = var.project
+
+  # If IAP is not used, use default backend service for unmatched requests
+  default_service = var.iap == null ? google_compute_backend_service.default.id : null
+
+  # If IAP is used, redirect unmatched requests to Atlantis domain
+  dynamic "default_url_redirect" {
+    for_each = var.iap != null ? [1] : []
+    content {
+      host_redirect          = var.domain
+      https_redirect         = true
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+      strip_query            = false
+    }
+  }
 
   # As Atlantis uses the `/events` path to handle incoming webhook events
   # we shouldn't put it behind IAP, it should be protected using a webhook secret.


### PR DESCRIPTION
## what
* Add `default_url_redirect` to `google_compute_url_map` when IAP is enabled

## why
* Even with IAP enabled, if you go to load balancer IP, you're taken straight to Atlantis UI, bypassing any authentication. This is because by default unmatched requests are handled by the `default` service

## references
* [google_compute_url_map#default_url_redirect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map#nested_default_url_redirect)