### PR TITLE
Adding IAP example and output for IAP backend service

### DIFF
--- a/examples/iap_enabled/README.md
+++ b/examples/iap_enabled/README.md
@@ -1,6 +1,8 @@
 # Using IAP to gate access to Atlantis
 
-This guide explains how to use IAP to gate access to your Atlantis deployment. For more information on this module, see [`basic example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic). For more on IAP specifically, see the [`Google docs on IAP`](https://cloud.google.com/iap/docs/concepts-overview).
+This guide explains how to use IAP to gate access to your Atlantis deployment. For more information on this module, see [`basic example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic).
+
+IAP allows you to put Google Auth (or an external SSO provider, if added outside Terraform) in front of the Atlantis UI, which is otherwise open to the world. For more on IAP specifically, see the [`Google docs on IAP`](https://cloud.google.com/iap/docs/concepts-overview).
 
 Note that only internal org IAP clients can be created via Terraform. External clients must be manually created via the GCP console. This is due to a current restriction in the Google API.
 

--- a/examples/iap_enabled/README.md
+++ b/examples/iap_enabled/README.md
@@ -2,6 +2,8 @@
 
 This guide explains how to use IAP to gate access to your Atlantis deployment. For more information on this module, see [`basic example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic). For more on IAP specifically, see the [`Google docs on IAP`](https://cloud.google.com/iap/docs/concepts-overview).
 
+Note that only internal org IAP clients can be created via Terraform. External clients must be manually created via the GCP console. This is due to a current restriction in the Google API.
+
 - [Prerequisites](#prerequisites)
 - [How to deploy](#how-to-deploy)
   - [Important](#important)

--- a/examples/iap_enabled/README.md
+++ b/examples/iap_enabled/README.md
@@ -2,6 +2,8 @@
 
 This guide explains how to use IAP to gate access to your Atlantis deployment. For more information on this module, see [`basic example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic).
 
+# Why you should use IAP
+
 IAP allows you to put Google Auth (or an external SSO provider, if added outside Terraform) in front of the Atlantis UI, which is otherwise open to the world. For more on IAP specifically, see the [`Google docs on IAP`](https://cloud.google.com/iap/docs/concepts-overview).
 
 Note that only internal org IAP clients can be created via Terraform. External clients must be manually created via the GCP console. This is due to a current restriction in the Google API.

--- a/examples/iap_enabled/README.md
+++ b/examples/iap_enabled/README.md
@@ -1,0 +1,25 @@
+# Using IAP to gate access to Atlantis
+
+This guide explains how to use IAP to gate access to your Atlantis deployment. For more information on this module, see [`basic example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic). For more on IAP specifically, see the [`Google docs on IAP`](https://cloud.google.com/iap/docs/concepts-overview).
+
+- [Prerequisites](#prerequisites)
+- [How to deploy](#how-to-deploy)
+  - [Important](#important)
+
+## Prerequisites
+
+This module expects that you already own or create the below resources yourself.
+
+- Google network, subnetwork and a Cloud NAT
+- Service account, [specifics can be found here](../../README.md#service-account)
+- Domain, [specifics can be found here](../../README.md#dns-record)
+
+If you prefer an example that includes the above resources, see [`complete example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete).
+
+## How to deploy
+
+See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/main.tf) and the [`server-atlantis.yaml`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/server-atlantis.yaml).
+
+## After it's successfully deployed
+
+Once you're done, see [Configuring Webhooks for Atlantis](https://www.runatlantis.io/docs/configuring-webhooks.html#configuring-webhooks)

--- a/examples/iap_enabled/iap.tf
+++ b/examples/iap_enabled/iap.tf
@@ -16,15 +16,14 @@ resource "google_iap_client" "atlantis" {
   project      = local.project_id
 }
 
-# This resource allows access to Atlantis. Note that a binding resource
-# is canonical for this specific role for the project, and overrides any
-# other controls for the project. If that isn't desirable, you may want
-# to grant these permissions with another resource.
-resource "google_iap_web_backend_service_iam_binding" "atlantis" {
+# The below resource will allow this person to access the UI via IAP.
+# Each person or entity you want to add to the allow list will need a
+# separate resource. If you would like to have a single place to define
+# your allow list, look into using the google_iap_web_backend_service_iam_binding
+# resource.
+resource "google_iap_web_backend_service_iam_member" "jane_atlantis" {
   web_backend_service = module.atlantis.iap_backend_service_name
   role                = "roles/iap.httpsResourceAccessor"
-  members = [
-    "user:you@example.com",
-  ]
-  project = local.project_id
+  member              = "user:jane@example.com"
+  project             = local.project_id
 }

--- a/examples/iap_enabled/iap.tf
+++ b/examples/iap_enabled/iap.tf
@@ -19,9 +19,7 @@ resource "google_iap_client" "atlantis" {
 # This resource allows access to Atlantis. Note that a binding resource
 # is canonical for this specific role for the project, and overrides any
 # other controls for the project. If that isn't desirable, you may want
-# to grant these permissions with another resource. Also, without any
-# condition, this grants access to all services secured with IAP in this
-# project.
+# to grant these permissions with another resource.
 resource "google_iap_web_backend_service_iam_binding" "atlantis" {
   web_backend_service = module.atlantis.iap_backend_service_name
   role                = "roles/iap.httpsResourceAccessor"

--- a/examples/iap_enabled/iap.tf
+++ b/examples/iap_enabled/iap.tf
@@ -1,0 +1,32 @@
+# These are the resources needed specifically in order to get IAP to
+# function. Note that some are used as inputs to the atlantis module in
+# main.tf.
+
+# Note that you can only have a single IAP brand per project; if you are
+# already using IAP in this project you will not need this resource.
+resource "google_iap_brand" "example" {
+  support_email     = "you@example.com"
+  application_title = "Atlantis"
+  project           = local.project_id
+}
+
+resource "google_iap_client" "atlantis" {
+  display_name = "Atlantis"
+  brand        = google_iap_brand.example.name
+  project      = local.project_id
+}
+
+# This resource allows access to Atlantis. Note that a binding resource
+# is canonical for this specific role for the project, and overrides any
+# other controls for the project. If that isn't desirable, you may want
+# to grant these permissions with another resource. Also, without any
+# condition, this grants access to all services secured with IAP in this
+# project.
+resource "google_iap_web_backend_service_iam_binding" "atlantis" {
+  web_backend_service = module.atlantis.iap_backend_service_name
+  role                = "roles/iap.httpsResourceAccessor"
+  members = [
+    "user:you@example.com",
+  ]
+  project = local.project_id
+}

--- a/examples/iap_enabled/main.tf
+++ b/examples/iap_enabled/main.tf
@@ -1,0 +1,79 @@
+locals {
+  project_id            = "<your-project-id>"
+  network               = "<your-network>"
+  subnetwork            = "<your-subnetwork>"
+  region                = "<your-region>"
+  zone                  = "<your-zone>"
+  domain                = "<example.com>"
+  managed_zone          = "<your-managed-zone>"
+
+  github_repo_allow_list = "github.com/example/*"
+  github_user            = "<your-github-handle>"
+  github_token           = "<your-github-user>"
+  github_webhook_secret  = "<your-github-webhook-secret>"
+}
+
+# Create a service account and attach the required Cloud Logging permissions to it.
+resource "google_service_account" "atlantis" {
+  account_id   = "atlantis"
+  display_name = "Service Account for Atlantis"
+  project      = local.project_id
+}
+
+resource "google_project_iam_member" "atlantis_log_writer" {
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.atlantis.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "atlantis_metric_writer" {
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.atlantis.email}"
+  project = local.project_id
+}
+
+module "atlantis" {
+  source     = "bschaatsbergen/atlantis/gce"
+  name       = "atlantis"
+  network    = local.network
+  subnetwork = local.subnetwork
+  region     = local.region
+  zone       = local.zone
+  service_account = {
+    email  = google_service_account.atlantis.email
+    scopes = ["cloud-platform"]
+  }
+  # Note: environment variables are shown in the Google Cloud UI
+  # See the `examples/secure-env-vars` if you want to protect sensitive information
+  env_vars = {
+    ATLANTIS_GH_USER           = local.github_user
+    ATLANTIS_GH_TOKEN          = local.github_token
+    ATLANTIS_GH_WEBHOOK_SECRET = local.github_webhook_secret
+    ATLANTIS_REPO_ALLOWLIST    = local.github_repo_allow_list
+    ATLANTIS_ATLANTIS_URL      = "https://${local.domain}"
+    ATLANTIS_REPO_CONFIG_JSON  = jsonencode(yamldecode(file("${path.module}/server-atlantis.yaml")))
+  }
+
+  # This configuration turns on IAP. Note that there is additional configuration in iap.tf that is necessary
+  # for this to function properly.
+  iap = {
+    oauth2_client_id     = google_iap_client.atlantis.client_id
+    oauth2_client_secret = google_iap_client.atlantis.secret
+  }
+
+  domain  = local.domain
+  project = local.project_id
+}
+
+# As your DNS records might be managed at another registrar's site, we create the DNS record outside of the module.
+# This record is mandatory in order to provision the managed SSL certificate successfully.
+resource "google_dns_record_set" "default" {
+  name         = "${local.domain}."
+  type         = "A"
+  ttl          = 60
+  managed_zone = local.managed_zone
+  rrdatas = [
+    module.atlantis.ip_address
+  ]
+  project = local.project_id
+}

--- a/examples/iap_enabled/server-atlantis.yaml
+++ b/examples/iap_enabled/server-atlantis.yaml
@@ -1,0 +1,6 @@
+repos:
+- id: /.*/
+  apply_requirements: [mergeable]
+  allowed_overrides: [apply_requirements, workflow]
+  allow_custom_workflows: true
+  delete_source_branch_on_merge: true

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "managed_ssl_certificate_expire_time" {
   value       = google_compute_managed_ssl_certificate.default.expire_time
   description = "Expire time of the Google Managed SSL certificate"
 }
+
+output "iap_backend_service_name" {
+  value       = var.iap != null ? google_compute_backend_service.iap[0].name : null
+  description = "Name of the optional IAP-enabled backend service"
+}


### PR DESCRIPTION
## what
This PR adds an additional output for the name of the IAP backend service, which is used as an input for the permissions binding used to gate access to the IAP-protected Atlantis deployment.

It also adds an additional example showing how to use IAP to protect Atlantis.

## why
The output eliminates the need to pull the name of the service via a data source (which would require the name to get the data source, so...) which also helps Terraform determine order of operations.

IAP has enough extra configuration I thought it worthy of describing in more detail, especially since I suspect most people will not want to have their UI just hanging out there on the internet.

## references
