### PR TITLE
Prevent COS image version update to cause a recreate of the instance template

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ You can check the status of the certificate in the Google Cloud Console.
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
+| <a name="input_disk_source_image"></a> [disk\_source\_image](#input\_disk\_source\_image) | The image from which to initialize this disk. This can be one of: the image's `self_link`, `projects/{project}/global/images/{image}`, `projects/{project}/global/images/family/{family}`, global/images/{image}, `global/images/family/{family}`, `family/{family}`, `{project}/{family}`, `{project}/{image}`, `{family}`, or `{image}`. | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
@@ -237,6 +238,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Description |
 |------|-------------|
 | <a name="output_cos_image_id"></a> [cos\_image\_id](#output\_cos\_image\_id) | The unique identifier of the Container-Optimized OS image used to create the Compute Engine instance. |
+| <a name="output_iap_backend_service_name"></a> [iap\_backend\_service\_name](#output\_iap\_backend\_service\_name) | Name of the optional IAP-enabled backend service |
 | <a name="output_ip_address"></a> [ip\_address](#output\_ip\_address) | The IPv4 address of the load balancer |
 | <a name="output_managed_ssl_certificate_certificate_id"></a> [managed\_ssl\_certificate\_certificate\_id](#output\_managed\_ssl\_certificate\_certificate\_id) | The unique identifier of the Google Managed SSL certificate |
 | <a name="output_managed_ssl_certificate_expire_time"></a> [managed\_ssl\_certificate\_expire\_time](#output\_managed\_ssl\_certificate\_expire\_time) | Expire time of the Google Managed SSL certificate |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ You can check the status of the certificate in the Google Cloud Console.
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
-| <a name="input_disk_source_image"></a> [disk\_source\_image](#input\_disk\_source\_image) | The image from which to initialize this disk. This can be one of: the image's `self_link`, `projects/{project}/global/images/{image}`, `projects/{project}/global/images/family/{family}`, global/images/{image}, `global/images/family/{family}`, `family/{family}`, `{project}/{family}`, `{project}/{image}`, `{family}`, or `{image}`. | `string` | `null` | no |
+| <a name="input_disk_source_image"></a> [disk\_source\_image](#input\_disk\_source\_image) | The image from which to initialize this disk. | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "google_compute_instance_template" "default" {
 
   # Ephemeral OS boot disk
   disk {
-    source_image = var.disk_source_image != "" ? var.disk_source_image : data.google_compute_image.cos.self_link
+    source_image = var.disk_source_image != null ? var.disk_source_image : data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
     disk_type    = "pd-ssd"

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ resource "google_compute_instance_template" "default" {
 
   # Ephemeral OS boot disk
   disk {
-    source_image = data.google_compute_image.cos.self_link
+    source_image = var.disk_source_image != "" ? var.disk_source_image : data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
     disk_type    = "pd-ssd"
@@ -196,6 +196,9 @@ resource "google_compute_instance_template" "default" {
   # In order to update an Instance Template, Terraform will destroy the existing resource and create a replacement
   lifecycle {
     create_before_destroy = true
+    ignore_changes = [
+      disk[0].source_image
+    ]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "machine_type" {
   default     = "n2-standard-2"
 }
 
+variable "disk_source_image" {
+  type        = string
+  description = "The image from which to initialize this disk. This can be one of: the image's `self_link`, `projects/{project}/global/images/{image}`, `projects/{project}/global/images/family/{family}`, global/images/{image}, `global/images/family/{family}`, `family/{family}`, `{project}/{family}`, `{project}/{image}`, `{family}`, or `{image}`."
+  default     = null
+}
+
 variable "persistent_disk_size_gb" {
   type        = number
   description = "The size of the persistent disk that Atlantis uses to store its data on"

--- a/variables.tf
+++ b/variables.tf
@@ -31,7 +31,7 @@ variable "machine_type" {
 
 variable "disk_source_image" {
   type        = string
-  description = "The image from which to initialize this disk. This can be one of: the image's `self_link`, `projects/{project}/global/images/{image}`, `projects/{project}/global/images/family/{family}`, global/images/{image}, `global/images/family/{family}`, `family/{family}`, `{project}/{family}`, `{project}/{image}`, `{family}`, or `{image}`."
+  description = "The image from which to initialize this disk."
   default     = null
 }
 


### PR DESCRIPTION
## what
* When `data.google_compute_image.cos` returns a new version of the COS image, it proposes a recreate of the instance template. Which also restarts Atlantis, this can be inconvenient especially if Atlantis is used to make this change. 

* I've added a variable to supply/overwrite your own image, and I've added an `ignore_changes` to the COS image that's used on the first time... downside of this is that you will not pull new versions of COS, unless you want to overwrite it through the var (or via the GCP console).

## why
* To not cause a recreate of Atlantis when applying the change. 

## references
* Closes #98 
