### PR TITLE
fix: ignore lock file for terraform-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: terraform_validate
         exclude: ^examples/
       - id: terraform_docs
+        args: ["--args=--lockfile=false"]
         exclude: ^examples/
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## what
* ignore lock file for terraform-docs

## why
* This maintains the `> x.y.z` qualifier in the readme docs for providers instead of reading resolved provider versions `a.b.c` directly from the lock file

## references
* https://terraform-docs.io/
