### PR TITLE
Set `privileged` to `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ You can check the status of the certificate in the Google Cloud Console.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.2.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | 4.47.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.2.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >=4.47.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >=3.4.3 |
 
 ## Modules
 
@@ -237,6 +237,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Description |
 |------|-------------|
 | <a name="output_cos_image_id"></a> [cos\_image\_id](#output\_cos\_image\_id) | The unique identifier of the Container-Optimized OS image used to create the Compute Engine instance. |
+| <a name="output_iap_backend_service_name"></a> [iap\_backend\_service\_name](#output\_iap\_backend\_service\_name) | Name of the optional IAP-enabled backend service |
 | <a name="output_ip_address"></a> [ip\_address](#output\_ip\_address) | The IPv4 address of the load balancer |
 | <a name="output_managed_ssl_certificate_certificate_id"></a> [managed\_ssl\_certificate\_certificate\_id](#output\_managed\_ssl\_certificate\_certificate\_id) | The unique identifier of the Google Managed SSL certificate |
 | <a name="output_managed_ssl_certificate_expire_time"></a> [managed\_ssl\_certificate\_expire\_time](#output\_managed\_ssl\_certificate\_expire\_time) | Expire time of the Google Managed SSL certificate |

--- a/main.tf
+++ b/main.tf
@@ -78,7 +78,7 @@ module "container" {
   container = {
     image = var.image
     securityContext = {
-      privileged = true
+      privileged = false
     }
     tty = true
     env = [for key, value in var.env_vars : {


### PR DESCRIPTION
## what
* When a container is given privileged mode it receives all permissions the host has, it's currently set to `true` but we should set it to `false` as it doesn't affect the atlantis installation.

## why
* Doesn't affect the atlantis installation.

## references
* Closes #102 
