### PR TITLE
examples: remove project from google_iap_client

### DIFF
--- a/examples/iap_enabled/iap.tf
+++ b/examples/iap_enabled/iap.tf
@@ -13,7 +13,6 @@ resource "google_iap_brand" "example" {
 resource "google_iap_client" "atlantis" {
   display_name = "Atlantis"
   brand        = google_iap_brand.example.name
-  project      = local.project_id
 }
 
 # The below resource will allow this person to access the UI via IAP.


### PR DESCRIPTION
```
╷
│ Error: Unsupported argument
│
│   on modules/atlantis/iap.tf line 16, in resource "google_iap_client" "atlantis":
│   16:   project      = var.project_id
│
│ An argument named "project" is not expected here.
╵
```

## what
A small change to IAP example I found during my deployment

## why
To make it work

## references
* Use `Closes #123`, if this PR closes a GitHub issue `#123`
* If possible, link to the relevant documentation to add some context.
