### PR TITLE
Allow pinning vm's machine image, instead of always using latest …stable/cos_cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |
+| <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The Machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used | `string` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to run Atlantis on | `string` | `"n2-standard-2"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Custom name that's used during resource creation | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Name of the network | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |
-| <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The Machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used | `string` | `null` | no |
+| <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used | `string` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to run Atlantis on | `string` | `"n2-standard-2"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Custom name that's used during resource creation | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | Name of the network | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -16,8 +16,7 @@ resource "random_string" "random" {
 }
 
 data "google_compute_image" "cos" {
-  name    = var.machine_image
-  family  = var.machine_image == null ? "cos-stable" : null
+  family  = "cos-stable"
   project = "cos-cloud"
 }
 
@@ -142,7 +141,7 @@ resource "google_compute_instance_template" "default" {
 
   # Ephemeral OS boot disk
   disk {
-    source_image = data.google_compute_image.cos.self_link
+    source_image = var.machine_image != null ? var.machine_image : data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
     disk_type    = "pd-ssd"

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,7 @@ resource "google_compute_instance_template" "default" {
 
   # Ephemeral OS boot disk
   disk {
-    source_image = data.google_compute_image.cos.self_link
+    source_image = var.machine_image != "" ? var.machine_image : data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
     disk_type    = "pd-ssd"

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,8 @@ resource "random_string" "random" {
 }
 
 data "google_compute_image" "cos" {
-  family  = "cos-stable"
+  name    = var.machine_image
+  family  = var.machine_image == null ? "cos-stable" : null
   project = "cos-cloud"
 }
 
@@ -141,7 +142,7 @@ resource "google_compute_instance_template" "default" {
 
   # Ephemeral OS boot disk
   disk {
-    source_image = var.machine_image != "" ? var.machine_image : data.google_compute_image.cos.self_link
+    source_image = data.google_compute_image.cos.self_link
     auto_delete  = true
     boot         = true
     disk_type    = "pd-ssd"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "zone" {
   description = "The zone that instances should be created in"
 }
 
+variable "machine_image" {
+  type = string
+  description = "The Machine image to create VMs with, if not specified, latest cos_stable/cos_cloud is used"
+  default = ""
+}
+
 variable "machine_type" {
   type        = string
   description = "The machine type to run Atlantis on"

--- a/variables.tf
+++ b/variables.tf
@@ -24,9 +24,9 @@ variable "zone" {
 }
 
 variable "machine_image" {
-  type = string
-  description = "The Machine image to create VMs with, if not specified, latest cos_stable/cos_cloud is used"
-  default = ""
+  type        = string
+  description = "The Machine image to create VMs with, if not specified, latest cos_cloud/cos_stable is used"
+  default     = null
 }
 
 variable "machine_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "zone" {
 
 variable "machine_image" {
   type        = string
-  description = "The Machine image to create VMs with, if not specified, latest cos_cloud/cos_stable is used"
+  description = "The machine image to create VMs with, if not specified, latest cos_cloud/cos_stable is used"
   default     = null
 }
 


### PR DESCRIPTION
## what
* Machine image is now pinnable
* Check the difference between two commits. If we keep only the first commit then `full` image name needs to be passed everytime. After the second commit you can just provide the short name and it will be verified. One drawback is that this it's not possible to move away from cos images, which probably is not desired anyway.

## why
* Not always you would want to stay on the latest cos image. Not always you want to update it if you're performing other changes.
* It also seems that not all latest `cos` images work well with atlantis/secure vm configurations.. Just today i was making tweaks to the module and latest image got deployed too. As a result backend never could be reached.. could not find any logs as to why this happened, but reverting the image instantly fixed the issue.

