### PR TITLE
GCP logging/monitoring configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |
+| <a name="input_google_logging_enabled"></a> [google\_logging\_enabled](#input\_google\_logging\_enabled) | Enable Google Cloud Logging | `bool` | `true` | no |
+| <a name="input_google_logging_use_fluentbit"></a> [google\_logging\_use\_fluentbit](#input\_google\_logging\_use\_fluentbit) | Enable Google Cloud Logging using Fluent Bit ( available from COS 105+ ) | `bool` | `false` | no |
+| <a name="input_google_monitoring_enabled"></a> [google\_monitoring\_enabled](#input\_google\_monitoring\_enabled) | Enable Google Cloud Monitoring | `bool` | `true` | no |
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,11 +1,15 @@
 locals {
-  project_id            = "<your-project-id>"
-  network               = "<your-network>"
-  subnetwork            = "<your-subnetwork>"
-  region                = "<your-region>"
-  zone                  = "<your-zone>"
-  domain                = "<example.com>"
-  managed_zone          = "<your-managed-zone>"
+  project_id                   = "<your-project-id>"
+  network                      = "<your-network>"
+  subnetwork                   = "<your-subnetwork>"
+  region                       = "<your-region>"
+  zone                         = "<your-zone>"
+  domain                       = "<example.com>"
+  managed_zone                 = "<your-managed-zone>"
+  enable_oslogin               = false
+  google_logging_enabled       = true
+  google_logging_use_fluentbit = false
+  google_monitoring_enabled    = true
 
   github_repo_allow_list = "github.com/example/*"
   github_user            = "<your-github-handle>"
@@ -33,12 +37,17 @@ resource "google_project_iam_member" "atlantis_metric_writer" {
 }
 
 module "atlantis" {
-  source     = "bschaatsbergen/atlantis/gce"
-  name       = "atlantis"
-  network    = local.network
-  subnetwork = local.subnetwork
-  region     = local.region
-  zone       = local.zone
+  source                       = "bschaatsbergen/atlantis/gce"
+  name                         = "atlantis"
+  network                      = local.network
+  subnetwork                   = local.subnetwork
+  region                       = local.region
+  zone                         = local.zone
+  enable_oslogin               = local.enable_oslogin
+  google_logging_enabled       = local.google_logging_enabled
+  google_logging_use_fluentbit = local.google_logging_use_fluentbit
+  google_monitoring_enabled    = local.google_monitoring_enabled
+
   service_account = {
     email  = google_service_account.atlantis.email
     scopes = ["cloud-platform"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,11 +1,13 @@
 locals {
-  project_id   = "<your-project-id>"
-  network      = "<your-network>"
-  subnetwork   = "<your-subnetwork>"
-  region       = "<your-region>"
-  zone         = "<your-zone>"
-  domain       = "<example.com>"
-  managed_zone = "<your-managed-zone>"
+  project_id                   = "<your-project-id>"
+  region                       = "<your-region>"
+  zone                         = "<your-zone>"
+  domain                       = "<example.com>"
+  managed_zone                 = "<your-managed-zone>"
+  enable_oslogin               = false
+  google_logging_enabled       = true
+  google_logging_use_fluentbit = false
+  google_monitoring_enabled    = true
 
   github_repo_allow_list = "github.com/example/*"
   github_user            = "<your-github-handle>"
@@ -69,12 +71,16 @@ resource "google_compute_router_nat" "default" {
 }
 
 module "atlantis" {
-  source     = "bschaatsbergen/atlantis/gce"
-  name       = "atlantis"
-  network    = google_compute_network.default.name
-  subnetwork = google_compute_subnetwork.default.name
-  region     = local.region
-  zone       = local.zone
+  source                       = "bschaatsbergen/atlantis/gce"
+  name                         = "atlantis"
+  network                      = google_compute_network.default.name
+  subnetwork                   = google_compute_subnetwork.default.name
+  region                       = local.region
+  zone                         = local.zone
+  enable_oslogin               = local.enable_oslogin
+  google_logging_enabled       = local.google_logging_enabled
+  google_logging_use_fluentbit = local.google_logging_use_fluentbit
+  google_monitoring_enabled    = local.google_monitoring_enabled
   service_account = {
     email  = google_service_account.atlantis.email
     scopes = ["cloud-platform"]

--- a/examples/secure-env-vars/main.tf
+++ b/examples/secure-env-vars/main.tf
@@ -1,12 +1,16 @@
 locals {
-  project_id            = "<your-project-id>"
-  network               = "<your-network>"
-  subnetwork            = "<your-subnetwork>"
-  region                = "<your-region>"
-  zone                  = "<your-zone>"
-  image                 = "<your-image>"
-  domain                = "<example.com>"
-  managed_zone          = "<your-managed-zone>"
+  project_id                   = "<your-project-id>"
+  network                      = "<your-network>"
+  subnetwork                   = "<your-subnetwork>"
+  region                       = "<your-region>"
+  zone                         = "<your-zone>"
+  image                        = "<your-image>"
+  domain                       = "<example.com>"
+  managed_zone                 = "<your-managed-zone>"
+  enable_oslogin               = false
+  google_logging_enabled       = true
+  google_logging_use_fluentbit = false
+  google_monitoring_enabled    = true
 
   github_repo_allow_list = "github.com/example/*"
 }
@@ -31,13 +35,16 @@ resource "google_project_iam_member" "atlantis_metric_writer" {
 }
 
 module "atlantis" {
-  source     = "bschaatsbergen/atlantis/gce"
-  name       = "atlantis"
-  image      = local.image # Your wrapper Atlantis Docker image
-  network    = local.network
-  subnetwork = local.subnetwork
-  region     = local.region
-  zone       = local.zone
+  source                       = "bschaatsbergen/atlantis/gce"
+  name                         = "atlantis"
+  image                        = local.image # Your wrapper Atlantis Docker image
+  network                      = local.network
+  subnetwork                   = local.subnetwork
+  region                       = local.region
+  zone                         = local.zone
+  google_logging_enabled       = local.google_logging_enabled
+  google_logging_use_fluentbit = local.google_logging_use_fluentbit
+  google_monitoring_enabled    = local.google_monitoring_enabled
   service_account = {
     email  = google_service_account.atlantis.email
     scopes = ["cloud-platform"]

--- a/main.tf
+++ b/main.tf
@@ -122,11 +122,13 @@ resource "google_compute_instance_template" "default" {
   metadata_startup_script = var.startup_script
 
   metadata = {
-    gce-container-declaration = module.container.metadata_value
-    user-data                 = data.cloudinit_config.config.rendered
-    google-logging-enabled    = true
-    block-project-ssh-keys    = var.block_project_ssh_keys_enabled
-    enable-oslogin            = var.enable_oslogin
+    gce-container-declaration    = module.container.metadata_value
+    user-data                    = data.cloudinit_config.config.rendered
+    google-logging-enabled       = var.google_logging_enabled
+    google-logging-use-fluentbit = var.google_logging_use_fluentbit
+    google-monitoring-enabled    = var.google_monitoring_enabled
+    block-project-ssh-keys       = var.block_project_ssh_keys_enabled
+    enable-oslogin               = var.enable_oslogin
   }
 
   # Using the below scheduling configuration,

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,21 @@ variable "labels" {
   description = "Key-value pairs representing labels attaching to instance & instance template"
   default     = {}
 }
+
+variable "google_logging_enabled" {
+  type        = bool
+  description = "Enable Google Cloud Logging"
+  default     = true
+}
+
+variable "google_logging_use_fluentbit" {
+  type        = bool
+  description = "Enable Google Cloud Logging using Fluent Bit ( available from COS 105+ )"
+  default     = false
+}
+
+variable "google_monitoring_enabled" {
+  type        = bool
+  description = "Enable Google Cloud Monitoring"
+  default     = true
+}


### PR DESCRIPTION
## what
* GCP logging and monitoring for container now configurable in the module
* cleanup examples and add the oslogin settings for the child module

## why
* GCP monitoring and logging are optional
* oslogin can be useful if we need to login into the VM / container 
