### PR TITLE
feat: add simple Terraform registry syntax example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ Here are some examples to choose from. Look at the prerequisites above to find o
 - [Complete](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete)
 - [Secure Environment Variables](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/secure-env-vars)
 
+
+```hcl
+module "atlantis" {
+  source  = "bschaatsbergen/atlantis/gce"
+  version = "1.3.1"
+  # insert the 7 required variables here
+}
+```
+
 ## How to deploy
 
 See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/main.tf) and the [`server-atlantis.yaml`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/server-atlantis.yaml).


### PR DESCRIPTION
## what
* Adds a simple example of the Terraform Module Registry syntax.

## why
* Makes it easier to implement as there's a bit of reference code.

## references
* Closes #56 
