### PR TITLE
Refactor locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ You can check the status of the certificate in the Google Cloud Console.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | >=2.2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >=4.47.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=4.79.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >=4.79.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >=3.4.3 |
 
 ## Providers
@@ -187,7 +188,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Version |
 |------|---------|
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.2.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | >=4.47.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >=4.79.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >=3.4.3 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ You can check the status of the certificate in the Google Cloud Console.
 |------|---------|
 | <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | >=2.2.0 |
 | <a name="provider_google"></a> [google](#provider\_google) | >=4.79.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >=4.79.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >=3.4.3 |
 
 ## Modules
@@ -201,6 +202,7 @@ You can check the status of the certificate in the Google Cloud Console.
 
 | Name | Type |
 |------|------|
+| [google-beta_google_compute_instance_group_manager.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_group_manager) | resource |
 | [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
 | [google_compute_backend_service.iap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
 | [google_compute_firewall.lb_health_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
@@ -208,7 +210,6 @@ You can check the status of the certificate in the Google Cloud Console.
 | [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
 | [google_compute_health_check.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
 | [google_compute_health_check.default_instance_group_manager](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
-| [google_compute_instance_group_manager.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
 | [google_compute_instance_template.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
 | [google_compute_managed_ssl_certificate.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
 | [google_compute_route.public_internet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_route) | resource |

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,16 @@
 locals {
-  # The default port that Atlantis runs on is 4141.
+  # The default port that Atlantis runs on is 4141, we default to this.
   atlantis_port = lookup(var.env_vars, "ATLANTIS_PORT", 4141)
-  # Atlantis its home directory is "/home/atlantis".
-  atlantis_data_dir    = lookup(var.env_vars, "ATLANTIS_DATA_DIR", "/home/atlantis")
-  port_name            = "atlantis"
-  network_traffic_tags = ["atlantis-${random_string.random.result}"]
-  labels               = merge(var.labels, { "container-vm" = module.container.vm_container_label })
+  # Atlantis its home directory is "/home/atlantis", we default to this.
+  atlantis_data_dir             = lookup(var.env_vars, "ATLANTIS_DATA_DIR", "/home/atlantis")
+  atlantis_port_name            = "atlantis"
+  atlantis_network_traffic_tags = ["atlantis-${random_string.random.result}"]
+  atlantis_labels = merge(
+    var.labels,
+    module.container.container_vm.labels,
+    { "vm" = module.container.container_vm.name },
+    { "app" = "atlantis" }
+  )
 }
 
 resource "random_string" "random" {
@@ -146,7 +151,12 @@ resource "google_compute_instance_template" "default" {
     boot         = true
     disk_type    = "pd-ssd"
     disk_size_gb = 10
-    labels       = local.labels
+    labels = merge(
+      local.atlantis_labels,
+      {
+        "disk-type" = "boot"
+      },
+    )
 
     dynamic "disk_encryption_key" {
       for_each = var.disk_kms_key_self_link != null ? [1] : []
@@ -163,7 +173,12 @@ resource "google_compute_instance_template" "default" {
     mode         = "READ_WRITE"
     disk_size_gb = var.persistent_disk_size_gb
     auto_delete  = false
-    labels       = local.labels
+    labels = merge(
+      local.atlantis_labels,
+      {
+        "disk-type" = "data"
+      },
+    )
 
     dynamic "disk_encryption_key" {
       for_each = var.disk_kms_key_self_link != null ? [1] : []
@@ -189,10 +204,8 @@ resource "google_compute_instance_template" "default" {
     scopes = var.service_account.scopes
   }
 
-  tags = concat(local.network_traffic_tags, var.tags)
-
-  labels = local.labels
-
+  tags    = concat(local.atlantis_network_traffic_tags, var.tags)
+  labels  = local.atlantis_labels
   project = var.project
 
   # Instance Templates cannot be updated after creation with the Google Cloud Platform API.
@@ -239,8 +252,12 @@ resource "google_compute_instance_group_manager" "default" {
     instance_template = google_compute_instance_template.default.id
   }
 
+  all_instances_config {
+    labels = local.atlantis_labels
+  }
+
   named_port {
-    name = local.port_name
+    name = local.atlantis_port_name
     port = local.atlantis_port
   }
 
@@ -264,7 +281,8 @@ resource "google_compute_instance_group_manager" "default" {
     max_unavailable_fixed          = 1
     replacement_method             = "RECREATE"
   }
-  project = var.project
+  project  = var.project
+  provider = google-beta
 }
 
 resource "google_compute_global_address" "default" {
@@ -283,7 +301,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
 resource "google_compute_backend_service" "default" {
   name                            = var.name
   protocol                        = "HTTP"
-  port_name                       = local.port_name
+  port_name                       = local.atlantis_port_name
   timeout_sec                     = 10
   connection_draining_timeout_sec = 5
   load_balancing_scheme           = "EXTERNAL_MANAGED"
@@ -306,7 +324,7 @@ resource "google_compute_backend_service" "iap" {
   count                           = var.iap != null ? 1 : 0
   name                            = "${var.name}-iap"
   protocol                        = "HTTP"
-  port_name                       = local.port_name
+  port_name                       = local.atlantis_port_name
   timeout_sec                     = 10
   connection_draining_timeout_sec = 5
   load_balancing_scheme           = "EXTERNAL_MANAGED"
@@ -403,7 +421,7 @@ resource "google_compute_route" "public_internet" {
   next_hop_gateway = "default-internet-gateway"
   priority         = 0
   project          = var.project
-  tags             = local.network_traffic_tags
+  tags             = local.atlantis_network_traffic_tags
 }
 
 # This firewall rule allows Google Cloud to issue the health checks
@@ -422,5 +440,5 @@ resource "google_compute_firewall" "lb_health_check" {
     data.google_netblock_ip_ranges.this["legacy-health-checkers"].cidr_blocks_ipv4,
   ))
   project     = var.project
-  target_tags = local.network_traffic_tags
+  target_tags = local.atlantis_network_traffic_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   # The default port that Atlantis runs on is 4141, we default to this.
   atlantis_port = lookup(var.env_vars, "ATLANTIS_PORT", 4141)
-  # Atlantis its home directory is "/home/atlantis", we default to this.
+  # Atlantis' home directory is "/home/atlantis", we default to this.
   atlantis_data_dir             = lookup(var.env_vars, "ATLANTIS_DATA_DIR", "/home/atlantis")
   atlantis_port_name            = "atlantis"
   atlantis_network_traffic_tags = ["atlantis-${random_string.random.result}"]

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">=4.47.0"
+      version = ">=4.79.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">=4.79.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
## what
* Renamed locals for consistency.
* Added labels (had to introduce the google-beta provider in order to place the labels on each instance in the managed instance group).

## why
* Having more labels available helps with identifying resources in Google Cloud (billing, etc).
* The locals could use some love and consistency.

**Note**: this is likely a breaking change as we're adding labels - causing the instance template to be recreated.
