### PR TITLE
Allow metrics to be exposed publicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Key-value pairs representing environment variables and their respective values | `map(any)` | n/a | yes |
+| <a name="input_expose_metrics_publicly"></a> [expose\_metrics\_publicly](#input\_expose\_metrics\_publicly) | Exposes the /metrics endpoint publicly even if Atlantis is protected by IAP | `bool` | `false` | no |
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -362,6 +362,18 @@ resource "google_compute_url_map" "default" {
     }
   }
 
+  dynamic "path_matcher" {
+    for_each = var.iap != null ? [1] : []
+    content {
+      name            = "events"
+      default_service = google_compute_backend_service.iap[0].id
+      path_rule {
+        paths   = ["/events"]
+        service = google_compute_backend_service.default.id
+      }
+    }
+  }
+
   # As Atlantis uses the `/metrics` path to expose certain metrics
   # we should make it possible to access it without IAP.
   dynamic "host_rule" {
@@ -375,10 +387,10 @@ resource "google_compute_url_map" "default" {
   dynamic "path_matcher" {
     for_each = var.iap != null ? [1] : []
     content {
-      name            = "events"
+      name            = "metrics"
       default_service = google_compute_backend_service.iap[0].id
       path_rule {
-        paths   = ["/events"]
+        paths   = ["/metrics"]
         service = google_compute_backend_service.default.id
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -362,6 +362,16 @@ resource "google_compute_url_map" "default" {
     }
   }
 
+  # As Atlantis uses the `/metrics` path to expose certain metrics
+  # we should make it possible to access it without IAP.
+  dynamic "host_rule" {
+    for_each = var.iap != null && var.expose_metrics_publicly ? [1] : []
+    content {
+      hosts        = [var.domain]
+      path_matcher = "metrics"
+    }
+  }
+
   dynamic "path_matcher" {
     for_each = var.iap != null ? [1] : []
     content {

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,12 @@ variable "project" {
   default     = null
 }
 
+variable "expose_metrics_publicly" {
+  type        = bool
+  description = "Exposes the /metrics endpoint publicly even if Atlantis is protected by IAP"
+  default     = false
+}
+
 variable "labels" {
   type        = map(any)
   description = "Key-value pairs representing labels attaching to instance & instance template"


### PR DESCRIPTION
## what
* Added a host rule and patch matcher to possibly expose metrics publicly. 

## why
*  As Atlantis uses the `/metrics` path to expose certain metrics, we should make it possible to access it without IAP.

## references
* Closes #120
