### PR TITLE
feat: add option to enable confidential vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ This Terraform module deploys various resources to run Atlantis on Google Comput
 
 - **Cloud Armor** - Use Google Cloud Armor security policies to protect the default backend service from distributed denial-of-service (DDoS) and other web-based attacks. Security policies can be configured manually, with configurable match conditions and actions in a security policy. Google Cloud Armor also features preconfigured security policies, which cover a variety of use cases.
 
+- **Confidential VM** - A Confidential VM is a type of Compute Engine VM that ensures that your data and applications stay private and encrypted even while in use. You can use a Confidential VM as part of your security strategy so you do not expose sensitive data or workloads during processing. Note that Confidential VM [does not support live migration](https://cloud.google.com/confidential-computing/confidential-vm/docs/error-messages#live_migration_isnt_supported), so if this feature is enabled, `onHostMaintenance` will be set to `TERMINATE`.
+
 ## Prerequisites
 
 This module expects that you already own or create the below resources yourself.

--- a/main.tf
+++ b/main.tf
@@ -142,7 +142,7 @@ resource "google_compute_instance_template" "default" {
     automatic_restart           = var.spot_machine_enabled ? false : true
     preemptible                 = var.spot_machine_enabled ? true : false
     provisioning_model          = var.spot_machine_enabled ? "SPOT" : "STANDARD"
-    on_host_maintenance         = var.spot_machine_enabled ? "TERMINATE" : "MIGRATE"
+    on_host_maintenance         = (var.spot_machine_enabled || var.enable_confidential_vm) ? "TERMINATE" : "MIGRATE"
     instance_termination_action = var.spot_machine_enabled ? "STOP" : null
   }
 
@@ -204,6 +204,10 @@ resource "google_compute_instance_template" "default" {
   service_account {
     email  = var.service_account.email
     scopes = var.service_account.scopes
+  }
+
+  confidential_instance_config {
+    enable_confidential_compute = var.enable_confidential_vm
   }
 
   tags    = concat(local.atlantis_network_traffic_tags, var.tags)

--- a/variables.tf
+++ b/variables.tf
@@ -181,3 +181,9 @@ variable "iap_backend_security_policy" {
   description = "Name of the security policy to apply to the IAP backend service"
   default     = null
 }
+
+variable "enable_confidential_vm" {
+  type        = bool
+  description = "Enable Confidential VM. If true, on host maintenance will be set to TERMINATE"
+  default     = false
+}


### PR DESCRIPTION
## what
* Give users the option to enable Confidential VM feature

## why
* Confidential VMs ensure that data and applications stay private and encrypted even while in use. This PR gives users the option to enable this feature and improve their security strategy.
* This feature is disabled by default to maintain backwards compatibility, and because Confidential VMs do not support live migration: https://cloud.google.com/confidential-computing/confidential-vm/docs/error-messages#live_migration_isnt_supported

## references
* Confidential Computing - https://cloud.google.com/confidential-computing/confidential-vm/docs/about-cvm
