### PR TITLE
Minor fix in Cloud Armor README

### DIFF
--- a/examples/cloud-armor/README.md
+++ b/examples/cloud-armor/README.md
@@ -25,7 +25,7 @@ If you prefer an example that includes the above resources, see [`complete examp
 
 ## How to deploy
 
-See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/main.tf) and the [`server-atlantis.yaml`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/server-atlantis.yaml).
+See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/cloud-armor/main.tf) and the [`server-atlantis.yaml`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/cloud-armor/server-atlantis.yaml).
 
 ## After it's successfully deployed
 


### PR DESCRIPTION
## what
* Fix a typo in the README.

## why
* It's referencing the incorrect example usage.