### PR TITLE
feat: shared vpc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Here are some examples to choose from. Look at the prerequisites above to find o
 - [Complete](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete)
 - [Secure Environment Variables](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/secure-env-vars)
 - [Cloud Armor](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/cloud-armor)
+- [Shared VPC](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/shared-vpc)
 
 ```hcl
 module "atlantis" {

--- a/examples/shared-vpc/README.md
+++ b/examples/shared-vpc/README.md
@@ -1,0 +1,33 @@
+# Example usage
+
+Read through the below before you deploy this module.
+
+- [Prerequisites](#prerequisites)
+- [How to deploy](#how-to-deploy)
+- [After it's successfully deployed](#after-its-successfully-deployed)
+
+## Prerequisites
+
+This module expects that you already own or create the below resources yourself.
+
+- Service account, [specifics can be found here](../../README.md#service-account)
+- Domain, [specifics can be found here](../../README.md#dns-record)
+- A host project with a Google network, subnetwork, a Cloud NAT, and the following firewall rules configured in the host network:
+  - Allow load balancer healthchecks: (<https://cloud.google.com/load-balancing/docs/health-checks#fw-rule>)
+    - source ip ranges: [130.211.0.0/22, 35.191.0.0/16]
+    - target tags [allow-lb-health-checks]
+    - tcp
+  - Allow IAP access, if applicable (<https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule>)
+    - source ip ranges: [35.235.240.0/20]
+    - target tags: [allow-iap]
+    - tcp, port 22
+
+If you prefer an example that includes the above resources, see [`complete example`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/complete).
+
+## How to deploy
+
+See [`main.tf`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/main.tf) and the [`server-atlantis.yaml`](https://github.com/bschaatsbergen/atlantis-on-gcp-vm/tree/master/examples/basic/server-atlantis.yaml).
+
+## After it's successfully deployed
+
+Once you're done, see [Configuring Webhooks for Atlantis](https://www.runatlantis.io/docs/configuring-webhooks.html#configuring-webhooks)

--- a/examples/shared-vpc/main.tf
+++ b/examples/shared-vpc/main.tf
@@ -1,0 +1,78 @@
+locals {
+  project_id      = "<your-project-id>"
+  network         = "<your-network>"
+  subnetwork      = "<your-subnetwork>"
+  region          = "<your-region>"
+  zone            = "<your-zone>"
+  domain          = "<example.com>"
+  managed_zone    = "<your-managed-zone>"
+  host_project_id = "<your-host-project-id>"
+
+  github_repo_allow_list = "github.com/example/*"
+  github_user            = "<your-github-handle>"
+  github_token           = "<your-github-user>"
+  github_webhook_secret  = "<your-github-webhook-secret>"
+}
+
+# Create a service account and attach the required Cloud Logging permissions to it.
+resource "google_service_account" "atlantis" {
+  account_id   = "atlantis"
+  display_name = "Service Account for Atlantis"
+  project      = local.project_id
+}
+
+resource "google_project_iam_member" "atlantis_log_writer" {
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.atlantis.email}"
+  project = local.project_id
+}
+
+resource "google_project_iam_member" "atlantis_metric_writer" {
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.atlantis.email}"
+  project = local.project_id
+}
+
+module "atlantis" {
+  source     = "bschaatsbergen/atlantis/gce"
+  name       = "atlantis"
+  network    = local.network
+  subnetwork = local.subnetwork
+  region     = local.region
+  zone       = local.zone
+  service_account = {
+    email  = google_service_account.atlantis.email
+    scopes = ["cloud-platform"]
+  }
+  # Note: environment variables are shown in the Google Cloud UI
+  # See the `examples/secure-env-vars` if you want to protect sensitive information
+  env_vars = {
+    ATLANTIS_GH_USER           = local.github_user
+    ATLANTIS_GH_TOKEN          = local.github_token
+    ATLANTIS_GH_WEBHOOK_SECRET = local.github_webhook_secret
+    ATLANTIS_REPO_ALLOWLIST    = local.github_repo_allow_list
+    ATLANTIS_ATLANTIS_URL      = "https://${local.domain}"
+    ATLANTIS_REPO_CONFIG_JSON  = jsonencode(yamldecode(file("${path.module}/server-atlantis.yaml")))
+  }
+  domain  = local.domain
+  project = local.project_id
+
+  shared_vpc = {
+    host_project_id = local.host_project_id
+  }
+
+  tags = ["allow-lb-health-checks", "allow-iap"]
+}
+
+# As your DNS records might be managed at another registrar's site, we create the DNS record outside of the module.
+# This record is mandatory in order to provision the managed SSL certificate successfully.
+resource "google_dns_record_set" "default" {
+  name         = "${local.domain}."
+  type         = "A"
+  ttl          = 60
+  managed_zone = local.managed_zone
+  rrdatas = [
+    module.atlantis.ip_address
+  ]
+  project = local.project_id
+}

--- a/examples/shared-vpc/server-atlantis.yaml
+++ b/examples/shared-vpc/server-atlantis.yaml
@@ -1,0 +1,6 @@
+repos:
+- id: /.*/
+  apply_requirements: [mergeable]
+  allowed_overrides: [apply_requirements, workflow]
+  allow_custom_workflows: true
+  delete_source_branch_on_merge: true

--- a/main.tf
+++ b/main.tf
@@ -192,7 +192,7 @@ resource "google_compute_instance_template" "default" {
 
   network_interface {
     subnetwork         = var.subnetwork
-    subnetwork_project = var.project
+    subnetwork_project = try(var.shared_vpc.host_project_id, var.project)
   }
 
   shielded_instance_config {
@@ -430,6 +430,7 @@ resource "google_compute_global_forwarding_rule" "https" {
 
 # Route public internet traffic to the default internet gateway
 resource "google_compute_route" "public_internet" {
+  count            = var.shared_vpc == null ? 1 : 0
   network          = var.network
   name             = "${var.name}-public-internet"
   description      = "Custom static route for Altantis to communicate with the public internet"
@@ -442,6 +443,7 @@ resource "google_compute_route" "public_internet" {
 
 # This firewall rule allows Google Cloud to issue the health checks
 resource "google_compute_firewall" "lb_health_check" {
+  count       = var.shared_vpc == null ? 1 : 0
   name        = "${var.name}-lb-health-checks"
   description = "Firewall rule to allow inbound Google Load Balancer health checks to the Atlantis instance"
   priority    = 0

--- a/variables.tf
+++ b/variables.tf
@@ -187,3 +187,11 @@ variable "enable_confidential_vm" {
   description = "Enable Confidential VM. If true, on host maintenance will be set to TERMINATE"
   default     = false
 }
+
+variable "shared_vpc" {
+  description = "Whether to deploy within a shared VPC"
+  type = object({
+    host_project_id = string
+  })
+  default = null
+}


### PR DESCRIPTION
## what
* Give users the option to deploy in shared vpc architectures
* When enabled, the firewall rule and default route are not created, and the host project id is used in the  instance template's network configuration.
* Create a new example using this feature under `examples/shared_vpc`

## why
* These changes allow this module to be deployed in projects that use Shared VPC

## references
* https://cloud.google.com/iap/docs/using-tcp-forwarding#create-firewall-rule
* https://cloud.google.com/load-balancing/docs/health-checks#fw-rule
* https://cloud.google.com/load-balancing/docs/l7-internal/l7-internal-shared-vpc#configure_firewall_rules
* Close #110

> Let me know how you feel about these changes and the accompanied example 😄 
