### PR TITLE
Adding security policy variable for IAP backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
+| <a name="input_default_backend_security_policy"></a> [default\_backend\_security\_policy](#input\_default\_backend\_security\_policy) | Name of the security policy to apply to the default backend service | `string` | `null` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |
 | <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enables OS Login service on the VM | `bool` | `false` | no |
@@ -237,6 +238,7 @@ You can check the status of the certificate in the Google Cloud Console.
 | <a name="input_google_logging_use_fluentbit"></a> [google\_logging\_use\_fluentbit](#input\_google\_logging\_use\_fluentbit) | Enable Google Cloud Logging using Fluent Bit | `bool` | `false` | no |
 | <a name="input_google_monitoring_enabled"></a> [google\_monitoring\_enabled](#input\_google\_monitoring\_enabled) | Enable Google Cloud Monitoring | `bool` | `true` | no |
 | <a name="input_iap"></a> [iap](#input\_iap) | Settings for enabling Cloud Identity Aware Proxy to protect the Atlantis UI | <pre>object({<br>    oauth2_client_id     = string<br>    oauth2_client_secret = string<br>  })</pre> | `null` | no |
+| <a name="input_iap_backend_security_policy"></a> [iap\_backend\_security\_policy](#input\_iap\_backend\_security\_policy) | Name of the security policy to apply to the IAP backend service | `string` | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | Docker image. This is most often a reference to a container located in a container registry | `string` | `"ghcr.io/runatlantis/atlantis:latest"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Key-value pairs representing labels attaching to instance & instance template | `map(any)` | `{}` | no |
 | <a name="input_machine_image"></a> [machine\_image](#input\_machine\_image) | The machine image to create VMs with, if not specified, latest cos\_cloud/cos\_stable is used | `string` | `null` | no |

--- a/examples/cloud-armor/README.md
+++ b/examples/cloud-armor/README.md
@@ -1,6 +1,6 @@
 # Example usage
 
-This example deploys Cloud Armor to ensure requests to the default backend are coming from GitHub Webhooks.
+This example deploys Cloud Armor to ensure requests to the default backend are coming from GitHub Webhooks, and adds another policy to restrict access to the IAP backend to an example CIDR.
 
 Since IAP is enabled, two backend services will be created:
 

--- a/main.tf
+++ b/main.tf
@@ -332,6 +332,7 @@ resource "google_compute_backend_service" "iap" {
   connection_draining_timeout_sec = 5
   load_balancing_scheme           = "EXTERNAL_MANAGED"
   health_checks                   = [google_compute_health_check.default.id]
+  security_policy                 = var.iap_backend_security_policy
 
   log_config {
     enable      = true

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,9 @@ variable "default_backend_security_policy" {
   description = "Name of the security policy to apply to the default backend service"
   default     = null
 }
+
+variable "iap_backend_security_policy" {
+  type        = string
+  description = "Name of the security policy to apply to the IAP backend service"
+  default     = null
+}


### PR DESCRIPTION
## what
This adds a variable which allows applying a Cloud Armor policy to the IAP backend service, in addition to the default.

## why
We'd like to be able to restrict access to the Atlantis UI, even with IAP added.

## references
This is basically just an extension of https://github.com/bschaatsbergen/terraform-gce-atlantis/pull/132 for the other backend.
