### PR TITLE
refactor!: gce-container-declaration deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,9 +204,7 @@ You can check the status of the certificate in the Google Cloud Console.
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_container"></a> [container](#module\_container) | terraform-google-modules/container-vm/google | ~> 3.2 |
+No modules.
 
 ## Resources
 
@@ -234,9 +232,9 @@ You can check the status of the certificate in the Google Cloud Console.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_args"></a> [args](#input\_args) | Arguments to override the container image default command (CMD). | `list(string)` | `null` | no |
+| <a name="input_args"></a> [args](#input\_args) | Arguments to override the container image default command (CMD). | `list(string)` | `[]` | no |
 | <a name="input_block_project_ssh_keys_enabled"></a> [block\_project\_ssh\_keys\_enabled](#input\_block\_project\_ssh\_keys\_enabled) | Blocks the use of project-wide publich SSH keys | `bool` | `false` | no |
-| <a name="input_command"></a> [command](#input\_command) | Command to override the container image ENTRYPOINT | `list(string)` | `null` | no |
+| <a name="input_command"></a> [command](#input\_command) | Command to override the container image ENTRYPOINT | `list(string)` | `[]` | no |
 | <a name="input_default_backend_security_policy"></a> [default\_backend\_security\_policy](#input\_default\_backend\_security\_policy) | Name of the security policy to apply to the default backend service | `string` | `null` | no |
 | <a name="input_disk_kms_key_self_link"></a> [disk\_kms\_key\_self\_link](#input\_disk\_kms\_key\_self\_link) | The self link of the encryption key that is stored in Google Cloud KMS | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain to associate Atlantis with and to request a managed SSL certificate for. Without `https://` | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -68,13 +68,13 @@ variable "image" {
 variable "command" {
   type        = list(string)
   description = "Command to override the container image ENTRYPOINT"
-  default     = null
+  default     = []
 }
 
 variable "args" {
   type        = list(string)
   description = "Arguments to override the container image default command (CMD)."
-  default     = null
+  default     = []
 }
 
 variable "env_vars" {


### PR DESCRIPTION
Due to the Compute Engine container startup agent deprecation on July 21 2025, GCP recommends now using a startup script or cloud-init to run containers in VMs.

To avoid impacting users that already have startup scripts, this commit uses cloud-init to spin up the container.

### Changes:

- Remove container module
- Add service responsible for the Atlantis container
- Changed `command` and `args` default values to `[]` instead of null, since we can't iterate null values

### Impact:

- `google_compute_disk.persistent will be updated in-place`
- `google_compute_instance_group_manager.default will be updated in-place`
- `google_compute_instance_template.default must be replaced`

**Requires a couple minutes of downtime while the VM is restarted.**

### Sources:

- https://cloud.google.com/compute/docs/deprecations/container-startup-agent-on-compute
- https://cloud.google.com/compute/docs/containers/migrate-containers

---

I tested creating and updating from an existing deployment, and it went as expected. Nonetheless, it would be best if someone else could confirm it 😄 

- Close #185
