### PR TITLE
fix: mount disk using cloud init

### DIFF
--- a/examples/secure-env-vars/main.tf
+++ b/examples/secure-env-vars/main.tf
@@ -60,7 +60,7 @@ module "atlantis" {
   command = ["/home/atlantis/custom-entrypoint.sh"]
   args    = ["server"]
 
-  startup_script = templatefile("${path.module}/custom-entrypoint.sh.tftpl", {
+  startup_script = templatefile("${path.module}/startup-script.sh.tftpl", {
     cloud_sdk_version          = "455.0.0"
     app_key_secret_name        = local.secret_names.app_key
     app_id_secret_name         = local.secret_names.app_id

--- a/examples/secure-env-vars/startup-script.sh.tftpl
+++ b/examples/secure-env-vars/startup-script.sh.tftpl
@@ -2,7 +2,15 @@
 
 set -e
 
-mkdir -p ${mount_folder}
+# cloud-init executes after the startup script, so we need to wait until the disk is mounted
+timeout 1m bash -c 'until /bin/findmnt -t ext4 -T ${mount_folder}'
+
+# if timeout failed, print msg
+if [ $? -ne 0 ]; then
+  echo "Error: Disk not mounted at ${mount_folder} within timeout period"
+  echo "Please rerun this script: 'google_metadata_script_runner startup'"
+fi 
+
 chown 100 ${mount_folder}
 cat <<'EOF' > "${mount_folder}/${entrypoint_filename}"
 #!/bin/bash

--- a/examples/secure-env-vars/startup-script.sh.tftpl
+++ b/examples/secure-env-vars/startup-script.sh.tftpl
@@ -3,7 +3,7 @@
 set -e
 
 # cloud-init executes after the startup script, so we need to wait until the disk is mounted
-timeout 1m bash -c 'until /bin/findmnt -t ext4 -T ${mount_folder}'
+timeout 1m bash -c "until /bin/findmnt -t ext4 -T ${mount_folder}; do sleep 1; done"
 
 # if timeout failed, print msg
 if [ $? -ne 0 ]; then

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,25 @@ data "cloudinit_config" "config" {
   base64_encode = false
 
   part {
+    # https://docs.cloud.google.com/compute/docs/disks/format-mount-disk-linux
+    # https://docs.cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#mounting_and_formatting_disks
+    filename     = "bootcmd"
+    content_type = "text/cloud-config"
+    merge_type   = "list(append)+dict(no_replace, recurse_list)+str()"
+    content = yamlencode({
+      bootcmd = [
+        # Format disk if not already formatted
+        "/sbin/blkid /dev/disk/by-id/google-${local.atlantis_persistent_disk_name} --probe --match-types ext4 || mkfs.ext4 -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-${local.atlantis_persistent_disk_name}",
+        # Check and repair filesystem
+        "/sbin/fsck.ext4 -tvy /dev/disk/by-id/google-${local.atlantis_persistent_disk_name}",
+        # Create mount point and mount the disk
+        "mkdir -p ${local.atlantis_disk_mount_path}",
+        "mount -t ext4 -o discard,defaults /dev/disk/by-id/google-${local.atlantis_persistent_disk_name} ${local.atlantis_disk_mount_path}"
+      ]
+    })
+  }
+
+  part {
     filename     = "runcmda"
     content_type = "text/cloud-config"
     merge_type   = "list(append)+dict(no_replace, recurse_list)+str()"


### PR DESCRIPTION
## what

* Properly format and mount disk with cloud-init.

## why

> We are replacing our Atlantis deployment with latest commit and found out the VM with persistent disk do not mount properly.
Although contents exist on /mnt/disks/gce-containers-mounts/gce-persistent-disks/atlantis-disk-0, the VM is actually seeing /mnt/disks path with 256K only due to tmpfs

## references

* Close #194
* https://docs.cloud.google.com/compute/docs/disks/format-mount-disk-linux
* https://docs.cloud.google.com/container-optimized-os/docs/concepts/disks-and-filesystem#mounting_and_formatting_disks
