### PR TITLE
feat: adding release workflow using semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,11 @@ on:
     branch:
       - main
 
+permissions:
+  contents: write
+  metadata: read
+  pull-requests: write
+  statuses: read
 jobs:
   release:
     name: Release
@@ -29,4 +34,4 @@ jobs:
         with:
           semantic_version: 25.0.2
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    branch:
+      - main
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    # Do not run release workflow on forks
+    if: github.repository_owner == 'runatlantis'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set correct Node.js version
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v5
+        with:
+          semantic_version: 25.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,9 @@
+{
+  "branches": ["main"],
+  "ci": false,
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+  ]
+}


### PR DESCRIPTION
## what
* Adds basic Github Action to create new releases using the `semantic-release` action.

## why
* Right now, we have no automated release process, which has been frustrating for users as it can take a while before new releases are made available on the Terraform registry.

## references
* Closes #136.